### PR TITLE
Modified to gather the Product DisplayName and SharedDllRefCount, among other things.

### DIFF
--- a/ComponentsGuidExtractor.ClassLibrary/Models/Component.cs
+++ b/ComponentsGuidExtractor.ClassLibrary/Models/Component.cs
@@ -21,6 +21,6 @@ namespace ComponentsGuidExtractor.ClassLibrary.Models
         /// <summary>
         /// Product list using this component
         /// </summary>
-        public List<Product> Products { get; set; }
+        public IList<Product> Products { get; set; }
     }
 }

--- a/ComponentsGuidExtractor.ClassLibrary/Models/Product.cs
+++ b/ComponentsGuidExtractor.ClassLibrary/Models/Product.cs
@@ -9,6 +9,11 @@ namespace ComponentsGuidExtractor.ClassLibrary.Models
     public class Product
     {
         /// <summary>
+        /// Represents the product display name in the registry based on the product id the component refers to.
+        /// </summary>
+        public string ProductName { get; set; }
+
+        /// <summary>
         /// Represents the value name field in the registry. 
         /// Which actually is the product Guid that the component is referenced to.
         /// </summary>
@@ -17,6 +22,11 @@ namespace ComponentsGuidExtractor.ClassLibrary.Models
         /// <summary>
         /// Represents value data field in the registry.
         /// </summary>
-        public string Value { get; set; }
+        public string FilePath { get; set; }
+
+        /// <summary>
+        /// Represents the reference count value for the specified FilePath in the SharedDlls registry location.
+        /// </summary>
+        public int SharedDllRefCount { get; set; }
     }
 }

--- a/ComponentsGuidExtractor.Console/ComponentsGuidExtractor.Console.csproj
+++ b/ComponentsGuidExtractor.Console/ComponentsGuidExtractor.Console.csproj
@@ -3,6 +3,17 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+    <Platforms>x86</Platforms>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <Prefer32Bit>false</Prefer32Bit>
+    <PlatformTarget>x86</PlatformTarget>
+    <OutputPath>bin\Debug\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
+    <OutputPath>bin\Release\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ComponentsGuidExtractor.Console/Program.cs
+++ b/ComponentsGuidExtractor.Console/Program.cs
@@ -26,21 +26,20 @@ namespace CompStringToGuidConverter
                 "vsjitdebuggerps.dll"
             };
 
-            string componentsRoot = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components";
-
             Console.WriteLine("Reading components registry...");
-            var extractedComponentsGuidDictionary = ComponentGuidFinder.FindComponentGuids(componentsRoot, filesList,
+            var extractedComponentsGuidDictionary = ComponentGuidFinder.FindComponentGuids(filesList,
                 ComponentsGuidExtractor.ClassLibrary.Enums.SearchType.FileName);
             Console.WriteLine("Read components registry.");
-            if (extractedComponentsGuidDictionary?.Count > 0)
+
+            if (extractedComponentsGuidDictionary != null && extractedComponentsGuidDictionary.Count > 0)
             {
                 string outputFileName = @"Extracted Components Guids.json";
                 
                 Console.WriteLine($"Writing to file '{outputFileName}'...");
 
-                File.WriteAllText(outputFileName, JsonSerializer.Serialize(extractedComponentsGuidDictionary
-                    , new JsonSerializerOptions { WriteIndented = true }));
-                
+                File.WriteAllText(outputFileName, JsonSerializer.Serialize(extractedComponentsGuidDictionary,
+                    new JsonSerializerOptions { WriteIndented = true }));
+
                 Console.WriteLine($"Components Guid written to file '{outputFileName}' successfully.");
             }
             else

--- a/ComponentsGuidExtractor.sln
+++ b/ComponentsGuidExtractor.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31424.327
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ComponentsGuidExtractor.Console", "ComponentsGuidExtractor.Console\ComponentsGuidExtractor.Console.csproj", "{EE07FF8F-C347-47BA-A0C8-B3B2F5E6B0FE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ComponentsGuidExtractor.Console", "ComponentsGuidExtractor.Console\ComponentsGuidExtractor.Console.csproj", "{EE07FF8F-C347-47BA-A0C8-B3B2F5E6B0FE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ComponentsGuidExtractor.ClassLibrary", "ComponentsGuidExtractor.ClassLibrary\ComponentsGuidExtractor.ClassLibrary.csproj", "{352B9430-D4C8-4DB4-B84E-7368B5F582A0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ComponentsGuidExtractor.ClassLibrary", "ComponentsGuidExtractor.ClassLibrary\ComponentsGuidExtractor.ClassLibrary.csproj", "{352B9430-D4C8-4DB4-B84E-7368B5F582A0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,10 +13,9 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{EE07FF8F-C347-47BA-A0C8-B3B2F5E6B0FE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EE07FF8F-C347-47BA-A0C8-B3B2F5E6B0FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EE07FF8F-C347-47BA-A0C8-B3B2F5E6B0FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EE07FF8F-C347-47BA-A0C8-B3B2F5E6B0FE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE07FF8F-C347-47BA-A0C8-B3B2F5E6B0FE}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{EE07FF8F-C347-47BA-A0C8-B3B2F5E6B0FE}.Debug|Any CPU.Build.0 = Debug|x86
+		{EE07FF8F-C347-47BA-A0C8-B3B2F5E6B0FE}.Release|Any CPU.ActiveCfg = Release|x86
 		{352B9430-D4C8-4DB4-B84E-7368B5F582A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{352B9430-D4C8-4DB4-B84E-7368B5F582A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{352B9430-D4C8-4DB4-B84E-7368B5F582A0}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Changed to gather the Product's DisplayName based on the component's productid and SharedDll RefCount based on the component's path.
Changed the componentsRoot registry path to be a const instead of passing it around, since it does not change.
Made some changes to better handle null values.
Changed to compile to an x86 executable since  the goal is to find info about x86 dlls.